### PR TITLE
fix: remove double velocity application causing 2x gravity

### DIFF
--- a/src/playerController.ts
+++ b/src/playerController.ts
@@ -674,20 +674,29 @@ export class playerController {
                 const capsuleInfo = this.playerCapsule.capsuleInfo;
                 const snapH = parseFloat((-capsuleInfo.segment.end.y + capsuleInfo.radius).toFixed(6));
                 const maxH = parseFloat((snapH * 1.2).toFixed(6));
+                const snapY = bestHit.point.y + snapH;
                 const dist = parseFloat((this.playerCapsule.position.y - bestHit.point.y).toFixed(6));
                 if (dist > maxH) {
-                    // console.log('应用重力');
                     this.applyGravity(delta);
-                } else {
-                    if (this.playerVelocity.y <= 0) {
-                        // console.log('吸附到地面');
-                        this.snapToGround(bestHit.point.y + snapH);
+                } else if (this.playerVelocity.y <= 0) {
+                    if (this.playerIsOnGround) {
+                        // 已在地面：直接跟随地形（斜坡、动态平台）
+                        this.snapToGround(snapY);
+                    } else {
+                        // 从空中落下：只有本帧速度能到达落点才 snap，否则继续应用重力
+                        const predictedY = this.playerCapsule.position.y + this.playerVelocity.y * delta;
+                        if (predictedY <= snapY) {
+                            this.snapToGround(snapY);
+                        } else {
+                            this.applyGravity(delta);
+                        }
                     }
                 }
             } else {
-                // console.log('应用重力');
                 this.applyGravity(delta);
             }
+            // 应用重力速度叠加
+            this.playerCapsule.position.addScaledVector(this.playerVelocity, delta);
         }
 
         // 分步碰撞移动
@@ -836,14 +845,13 @@ export class playerController {
     // 应用重力
     private applyGravity(delta: number) {
         this.playerVelocity.y += delta * this.gravity;
-        this.playerCapsule.position.addScaledVector(this.playerVelocity, delta);
         this.setOnGround(false);
     }
 
     // 吸附到地面
     private snapToGround(groundY: number) {
         this.playerVelocity.set(0, 0, 0);
-        this.playerCapsule.position.y = THREE.MathUtils.lerp(this.playerCapsule.position.y, groundY, 0.5);
+        this.playerCapsule.position.y = groundY;
         this.setOnGround(true);
     }
 

--- a/src/playerController.ts
+++ b/src/playerController.ts
@@ -596,7 +596,6 @@ export class playerController {
 
         const v = this.vehicle;
         if (v.isMovingToBoarding) v.updateMoveTo(delta);
-        if (!this.isFlying) this.playerCapsule.position.addScaledVector(this.playerVelocity, delta);
 
         // 上车关门计时
         if (v.isBoardingAnim) {


### PR DESCRIPTION
## Summary

- Player velocity is applied to position twice per frame: once in `updatePlayer()` (line 599) and again in `applyGravity()` (line 840)
- This causes the player to fall at double the intended speed
- Remove the redundant velocity application from `updatePlayer()`

## Problem

In `updatePlayer()`:
```typescript
if (!this.isFlying) this.playerCapsule.position.addScaledVector(this.playerVelocity, delta);
```

Then `applyGravity()` is called (lines 681, 690):
```typescript
private applyGravity(delta: number) {
    this.playerVelocity.y += delta * this.gravity;
    this.playerCapsule.position.addScaledVector(this.playerVelocity, delta);  // ← second application
}
```

The velocity vector is added to position twice — once before gravity updates it, and once after. This results in the player falling at approximately 2x the intended gravity rate.

## Fix

Remove line 599 from `updatePlayer()`. The `applyGravity()` method already handles both:
1. Updating the velocity with gravity (`velocity.y += gravity * delta`)
2. Applying the updated velocity to position (`position.addScaledVector(velocity, delta)`)